### PR TITLE
fixing the spheres 3d example

### DIFF
--- a/examples/spheres/spheres.c
+++ b/examples/spheres/spheres.c
@@ -33,6 +33,7 @@ int main(int argc, char ** argv)
       }
     }
   }
+  sp_image_write(density, "density.h5", 0);
 
   Image * img = sp_image_fft(density);
 
@@ -40,7 +41,6 @@ int main(int argc, char ** argv)
     img->mask->data[i] = 1;
   }
 
-  //Image * img = sp_image_generate_pattern(100);
   Image * tmp = sp_image_duplicate(img,SP_COPY_DATA|SP_COPY_MASK);
 
   sp_image_conj(tmp);

--- a/examples/spheres/spheres.c
+++ b/examples/spheres/spheres.c
@@ -1,8 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include <hdf5.h>
-#include <mpi.h>
 
 #include "spimage.h"
 
@@ -21,16 +19,16 @@ int main(int argc, char ** argv)
     for(y=0; y<sp_image_y(density); y++){
       for(z=0; z<sp_image_z(density); z++){
 	if((x-45)*(x-45)+(y-47)*(y-47)+(z-40)*(z-40) <= 5){
-	  sp_image_set(density,x,y,z,5);
+	  sp_image_set(density,x,y,z,sp_cinit(5,0));
 	}
 	if((x-55)*(x-55)+(y-47)*(y-47)+(z-49)*(z-49) <= 9){
-	  sp_image_set(density,x,y,z,4);
+	  sp_image_set(density,x,y,z,sp_cinit(4,0));
 	}
 	if((x-50)*(x-50)+(y-57)*(y-57)+(z-52)*(z-52) <= 12){
-	  sp_image_set(density,x,y,z,7);
+	  sp_image_set(density,x,y,z,sp_cinit(7,0));
 	}
 	if((x-50)*(x-50)+(y-50)*(y-50)+(z-58)*(z-58) <= 8){
-	  sp_image_set(density,x,y,z,3);
+	  sp_image_set(density,x,y,z,sp_cinit(3,0));
 	}
       }
     }

--- a/examples/spheres/uwrapc.conf
+++ b/examples/spheres/uwrapc.conf
@@ -1,35 +1,16 @@
-amplitudes_file = "spheres.h5";
-initial_blur_radius = 1.00000000;
-patterson_threshold = 0.0100000;
-beta = 0.79999998;
-innerloop_iterations = 20;
-added_noise = 0.00000000;
-beamstop_radius = 0.00000000;
-support_intensity_threshold = 0.15000000;
-iterations_to_min_blur = 500;
-minimum_blur_radius = 0.29999999;
-enforce_reality = 0;
-logfile = "uwrapc.log";
-output_period = 40;
-log_output_period = 5;
-algorithm = "HIO";
-blur_radius_reduction_method = "gaussian";
-RAAR_sigma = 0.10000000;
-dynamic_beta = 0.00000000;
-random_initial_intensities = 1;
-work_directory = ".";
-patterson_level_algorithm= "fixed";#default:"fixed"
-support_update_algorithm = "fixed";#"fixed" or "constant_area"
-object_area= 0.0000076;#actual area 0.0000046%
-support_real_error_threshold = -1.00000000;
-output_precision = "single";
-error_reduction_iterations_after_loop = 0;
-enforce_positivity = 0;
-genetic_optimization = 0;
-charge_flip_sigma = 0.00000010;
-rescale_amplitudes = 1;
-square_mask = 0.00000000;
-blur_patterson = 0;
-remove_central_pixel_phase = 0;
-perturb_weak_reflections = 0.000000;
-max_iterations = 50;
+input_data :
+{
+  intensities_file = "spheres.h5";
+};
+support_update_method :
+{
+  support_update_algorithm = "threshold";
+  support_intensity_threshold = 0.2;
+};
+
+nthreads = 4;
+max_iterations = 400;
+random_seed = -1;
+debug_level = 0;
+phasing_engine = "automatic";
+


### PR DESCRIPTION
To teach myself how to do 3d reconstructions, I reinstated the spheres example. Looks to me like it had fallen behind after changes in `libspimage` and the config file format.